### PR TITLE
fix: amount calculation in the rgbpp address balance endpoint

### DIFF
--- a/src/routes/rgbpp/address.ts
+++ b/src/routes/rgbpp/address.ts
@@ -175,7 +175,7 @@ const addressRoutes: FastifyPluginCallback<Record<never, never>, Server, ZodType
 
       const pendingOutputCellsGroup = await Promise.all(
         pendingTxids.map(async (txid) => {
-          const cells = await fastify.transactionProcessor.getPendingOuputCellsByTxid(txid);
+          const cells = await fastify.transactionProcessor.getPendingOutputCellsByTxid(txid);
           const lockArgsSet = new Set(pendingUtxosGroup[txid].map((utxo) => buildPreLockArgs(utxo.vout)));
           return cells.filter((cell) => lockArgsSet.has(cell.cellOutput.lock.args));
         }),

--- a/src/services/transaction.ts
+++ b/src/services/transaction.ts
@@ -608,12 +608,32 @@ export default class TransactionProcessor
     const { ckbVirtualResult } = job.data;
     const outputs = ckbVirtualResult.ckbRawTx.outputs;
     return outputs.map((output, index) => {
-      const cell: Cell = {
+      return Cell.parse({
         cellOutput: output,
         data: ckbVirtualResult.ckbRawTx.outputsData[index],
-      };
-      return cell;
+      });
     });
+  }
+
+  /**
+   * get pending input cells by txid, get ckb input cells from the uncompleted job
+   * @param txid - the transaction id
+   */
+  public async getPendingInputCellsByTxid(txid: string): Promise<Cell[]> {
+    const job = await this.getTransactionRequest(txid);
+    if (!job) {
+      return [];
+    }
+
+    // get ckb input cells from the uncompleted job only
+    const state = await job.getState();
+    if (state === 'completed' || state === 'failed') {
+      return [];
+    }
+
+    const { ckbVirtualResult } = job.data;
+    const inputOutPoints = ckbVirtualResult.ckbRawTx.inputs.map((input) => input.previousOutput!);
+    return await this.cradle.ckb.getInputCellsByOutPoint(inputOutPoints);
   }
 
   /**

--- a/src/services/transaction.ts
+++ b/src/services/transaction.ts
@@ -593,7 +593,7 @@ export default class TransactionProcessor
    * get pending output cells by txid, get ckb output cells from the uncompleted job
    * @param txid - the transaction id
    */
-  public async getPendingOuputCellsByTxid(txid: string) {
+  public async getPendingOutputCellsByTxid(txid: string): Promise<Cell[]> {
     const job = await this.getTransactionRequest(txid);
     if (!job) {
       return [];

--- a/test/routes/__snapshots__/token.test.ts.snap
+++ b/test/routes/__snapshots__/token.test.ts.snap
@@ -1,17 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`\`/token/generate\` - 400 1`] = `
-"[
-  {
-    "code": "invalid_type",
-    "expected": "object",
-    "received": "null",
-    "path": [],
-    "message": "Expected object, received null"
-  }
-]"
-`;
-
 exports[`\`/token/generate\` - without params 1`] = `
 "[
   {

--- a/test/routes/rgbpp/__snapshots__/address.test.ts.snap
+++ b/test/routes/rgbpp/__snapshots__/address.test.ts.snap
@@ -6889,7 +6889,7 @@ exports[`/:btc_address/balance - with pending_amount 1`] = `
       "name": "Unique BBQ",
       "pending_amount": "0x5f5e100",
       "symbol": "",
-      "total_amount": "0xbebc200",
+      "total_amount": "0x5f5e100",
       "type_hash": "0x78e21efcf107e7886eadeadecd1a01cfb88f1e5617f4438685db55b3a540d202",
       "type_script": {
         "args": "0x30d3fbec9ceba691770d57c6d06bdb98cf0f82bef0ca6e87687a118d6ce1e7b7",
@@ -6903,7 +6903,7 @@ exports[`/:btc_address/balance - with pending_amount 1`] = `
       "name": "XUDT Test Token",
       "pending_amount": "0x5f5e100",
       "symbol": "PDD",
-      "total_amount": "0x5f5e100",
+      "total_amount": "0x0",
       "type_hash": "0x10f511f2efb0027191b97ac5b4bd77374ffdac7399e8527d76f5f9bd32e7d35b",
       "type_script": {
         "args": "0x8c556e92974a8dd8237719020a259d606359ac2cc958cb8bda77a1c3bb3cd93b",

--- a/test/routes/rgbpp/address.test.ts
+++ b/test/routes/rgbpp/address.test.ts
@@ -92,8 +92,8 @@ describe('/rgbpp/v1/address', () => {
       mockRgbppUtxoPairs as RgbppUtxoCellsPair[],
     );
     const transactionProcessor = fastify.container.resolve('transactionProcessor');
-    const getPendingOuputCellsByTxidSpy = vi
-      .spyOn(transactionProcessor, 'getPendingOuputCellsByTxid')
+    const getPendingOutputCellsByTxidSpy = vi
+      .spyOn(transactionProcessor, 'getPendingOutputCellsByTxid')
       .mockResolvedValueOnce([
         {
           cellOutput: {
@@ -155,11 +155,11 @@ describe('/rgbpp/v1/address', () => {
     });
     const data = response.json();
 
-    expect(getPendingOuputCellsByTxidSpy).toBeCalledTimes(2);
-    expect(getPendingOuputCellsByTxidSpy).toHaveBeenCalledWith(
+    expect(getPendingOutputCellsByTxidSpy).toBeCalledTimes(2);
+    expect(getPendingOutputCellsByTxidSpy).toHaveBeenCalledWith(
       'aab2d8fc3f064087450057ccb6012893cf219043d8c915fe64c5322c0eeb6fd2',
     );
-    expect(getPendingOuputCellsByTxidSpy).toHaveBeenCalledWith(
+    expect(getPendingOutputCellsByTxidSpy).toHaveBeenCalledWith(
       '989f4e03179e17cbb6edd446f57ea6107a40ba23441056653f1cc34b7dd1e5ba',
     );
     expect(response.statusCode).toBe(200);


### PR DESCRIPTION
## Changes
- Fix #202 

## Fix details

The calculation in the `/rgbpp/address/{btc_address}/balance` endpoint has been refactored to:

- **Confirmed UTXOs:**
  1. Get all UTXOs
  2. Filter for all confirmed UTXOs
  3. Find the isomorphic XUDT cells corresponding to the UTXOs
  4. Add the amount of each target cell to the `total_amount` and `available_amount` fields

- **Unconfirmed UTXOs:**
  1. Get all UTXOs
  2. Filter for all unconfirmed UTXOs
  3. Find the isomorphic XUDT cells corresponding to the UTXOs
  4. Add the amount of each target cell to the `pending_amount` field

- **Unconfirmed Spent Outputs:**
  1. Get all transactions for the target BTC address
  5. Filter out all unconfirmed BTC transactions from the total transactions
  6. Find all RgbppLock XUDT cells in the inputs of the unconfirmed transactions
  7. Filter the above input cells to include only those belonging to the target BTC address
  8. Add the amount of each filtered cell to the `total_amount` field