### PR TITLE
refactor: use constants to replace local variables

### DIFF
--- a/src/services/bitcoin/index.ts
+++ b/src/services/bitcoin/index.ts
@@ -6,7 +6,7 @@ import { Cradle } from '../../container';
 import { IBitcoinBroadcastBackuper, IBitcoinDataProvider } from './interface';
 import { MempoolClient } from './mempool';
 import { ElectrsClient } from './electrs';
-import { NetworkType } from '../../constants';
+import { IS_MAINNET, NetworkType } from '../../constants';
 import { ChainInfo } from './schema';
 
 // https://github.com/mempool/electrs/blob/d4f788fc3d7a2b4eca4c5629270e46baba7d0f19/src/errors.rs#L6
@@ -169,7 +169,7 @@ export default class BitcoinClient implements IBitcoinClient {
 
     const { difficulty, mediantime } = tip;
     return {
-      chain: this.cradle.env.NETWORK === 'mainnet' ? 'main' : 'test',
+      chain: IS_MAINNET ? 'main' : 'test',
       blocks: tip.height,
       bestblockhash: hash,
       difficulty,

--- a/src/services/ckb.ts
+++ b/src/services/ckb.ts
@@ -24,6 +24,7 @@ import DataCache from './base/data-cache';
 import { scriptToHash } from '@nervosnetwork/ckb-sdk-utils';
 import { Cell } from '../routes/rgbpp/types';
 import { uniq } from 'lodash';
+import { IS_MAINNET } from '../constants';
 
 export type TransactionWithStatus = Awaited<ReturnType<CKBRPC['getTransaction']>>;
 
@@ -164,11 +165,10 @@ export default class CKBClient {
    * Get the ckb script configs
    */
   public getScripts() {
-    const isMainnet = this.cradle.env.NETWORK === 'mainnet';
-    const xudtTypeScript = getXudtTypeScript(isMainnet);
-    const sporeTypeScript = getSporeTypeScript(isMainnet);
-    const uniqueCellTypeScript = getUniqueTypeScript(isMainnet);
-    const inscriptionTypeScript = getInscriptionInfoTypeScript(isMainnet);
+    const xudtTypeScript = getXudtTypeScript(IS_MAINNET);
+    const sporeTypeScript = getSporeTypeScript(IS_MAINNET);
+    const uniqueCellTypeScript = getUniqueTypeScript(IS_MAINNET);
+    const inscriptionTypeScript = getInscriptionInfoTypeScript(IS_MAINNET);
     return {
       XUDT: xudtTypeScript,
       SPORE: sporeTypeScript,
@@ -297,12 +297,11 @@ export default class CKBClient {
       return cachedData as ReturnType<typeof decodeInfoCellData>;
     }
 
-    const isMainnet = this.cradle.env.NETWORK === 'mainnet';
     const txs = await this.getAllInfoCellTxs();
     for (const tx of txs) {
       // check if the unique cell is the info cell of the xudt type
       const uniqueCellIndex = tx.transaction.outputs.findIndex((cell) => {
-        return cell.type && isUniqueCellTypeScript(cell.type, isMainnet);
+        return cell.type && isUniqueCellTypeScript(cell.type, IS_MAINNET);
       });
       if (uniqueCellIndex !== -1) {
         const infoCellData = this.getUniqueCellData(tx, uniqueCellIndex, script);
@@ -313,7 +312,7 @@ export default class CKBClient {
       }
       // check if the inscription cell is the info cell of the xudt type
       const inscriptionCellIndex = tx.transaction.outputs.findIndex((cell) => {
-        return cell.type && isInscriptionInfoTypeScript(cell.type, isMainnet);
+        return cell.type && isInscriptionInfoTypeScript(cell.type, IS_MAINNET);
       });
       if (inscriptionCellIndex !== -1) {
         const infoCellData = this.getInscriptionInfoCellData(tx, inscriptionCellIndex, script);

--- a/src/services/paymaster.ts
+++ b/src/services/paymaster.ts
@@ -5,6 +5,7 @@ import { AppendPaymasterCellAndSignTxParams, IndexerCell, appendPaymasterCellAnd
 import { hd, config, BI } from '@ckb-lumos/lumos';
 import * as Sentry from '@sentry/node';
 import { Transaction } from '../routes/bitcoin/types';
+import { IS_MAINNET } from '../constants';
 
 interface IPaymaster {
   getNextCell(token: string): Promise<IndexerCell | null>;
@@ -60,8 +61,7 @@ export default class Paymaster implements IPaymaster {
 
   private get lockScript() {
     const args = hd.key.privateKeyToBlake160(this.ckbPrivateKey);
-    const scripts =
-      this.cradle.env.NETWORK === 'mainnet' ? config.predefined.LINA.SCRIPTS : config.predefined.AGGRON4.SCRIPTS;
+    const scripts = IS_MAINNET ? config.MAINNET.SCRIPTS : config.TESTNET.SCRIPTS;
     const template = scripts['SECP256K1_BLAKE160']!;
     const lockScript = {
       codeHash: template.CODE_HASH,
@@ -123,8 +123,7 @@ export default class Paymaster implements IPaymaster {
    * The paymaster CKB address to pay the time cells spent tx fee
    */
   public get ckbAddress() {
-    const isMainnet = this.cradle.env.NETWORK === 'mainnet';
-    const lumosConfig = isMainnet ? config.predefined.LINA : config.predefined.AGGRON4;
+    const lumosConfig = IS_MAINNET ? config.MAINNET : config.TESTNET;
     const args = hd.key.privateKeyToBlake160(this.ckbPrivateKey);
     const template = lumosConfig.SCRIPTS['SECP256K1_BLAKE160'];
     const lockScript = {
@@ -296,7 +295,7 @@ export default class Paymaster implements IPaymaster {
         sumInputsCapacity,
         paymasterCell,
         secp256k1PrivateKey: this.ckbPrivateKey,
-        isMainnet: this.cradle.env.NETWORK === 'mainnet',
+        isMainnet: IS_MAINNET,
       });
       this.cradle.logger.info(`[Paymaster] Signed transaction: ${JSON.stringify(signedTx)}`);
       return signedTx;

--- a/src/services/rgbpp.ts
+++ b/src/services/rgbpp.ts
@@ -66,7 +66,7 @@ class RgbppCollectorError extends Error {
  * will be recollected when the utxos are updated or new collect job is enqueued.
  */
 export default class RgbppCollector extends BaseQueueWorker<IRgbppCollectRequest, IRgbppCollectJobReturn> {
-  private readonly limit: pLimit.Limit;
+  private limit: pLimit.Limit;
   private dataCache: DataCache<IRgbppCollectJobReturn>;
 
   constructor(private cradle: Cradle) {


### PR DESCRIPTION
## Changes
- Replace local `isMainnet` and `testnetType` variables with constants `IS_MAINNET` and `TESTNET_TYPE`
- Replace local rgbpp-lock related methods with utils like `getRgbppLock` and `isRgbppLock`
- Replace local btc-time-lock related methods with utils like `getBtcTimeLock` and `isBtcTimeLock`
- Replace `config.predefined.LINA` to `config.MAINNET` and `config.predefined.AGGRON4` to `config.TESTNET`
- Fix some minor typos