### PR TITLE
fix: missing basic validation in route params

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -66,7 +66,7 @@ export const validatorCompiler: FastifySchemaCompiler<ZodAny> =
   (data) => {
     const result = schema.safeParse(data);
     if (result.success) {
-      return result.data;
+      return { value: result.data };
     }
 
     const error = result.error;

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import fastify from 'fastify';
+import fastify, { type FastifySchemaCompiler } from 'fastify';
 import { FastifyInstance } from 'fastify';
 import sensible from '@fastify/sensible';
 import compress from '@fastify/compress';
@@ -12,7 +12,7 @@ import { getSafeEnvs } from './env';
 import container from './container';
 import { asValue } from 'awilix';
 import options from './options';
-import { serializerCompiler, validatorCompiler, ZodTypeProvider } from 'fastify-type-provider-zod';
+import { serializerCompiler, ZodTypeProvider } from 'fastify-type-provider-zod';
 import cors from './plugins/cors';
 import { NetworkType } from './constants';
 import rgbppRoutes from './routes/rgbpp';
@@ -23,6 +23,7 @@ import internalRoutes from './routes/internal';
 import healthcheck from './plugins/healthcheck';
 import sentry from './plugins/sentry';
 import cron from './plugins/cron';
+import { ZodAny, ZodError } from 'zod';
 
 async function routes(fastify: FastifyInstance) {
   fastify.log.info(`Process env: ${JSON.stringify(getSafeEnvs(), null, 2)}`);
@@ -58,6 +59,23 @@ async function routes(fastify: FastifyInstance) {
     });
   }
 }
+
+export const validatorCompiler: FastifySchemaCompiler<ZodAny> =
+  ({ schema }) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (data): any => {
+    try {
+      return { value: schema.parse(data) };
+    } catch (error) {
+      if (error instanceof ZodError && error.errors.length) {
+        const firstError = error.errors[0];
+        return {
+          error: new Error(`Invalid ${firstError.path.join('.')}: ${error.errors[0].message}`),
+        };
+      }
+      return { error };
+    }
+  };
 
 export function buildFastify() {
   const app = fastify(options).withTypeProvider<ZodTypeProvider>();

--- a/src/app.ts
+++ b/src/app.ts
@@ -72,8 +72,9 @@ export const validatorCompiler: FastifySchemaCompiler<ZodAny> =
     const error = result.error;
     if (error.errors.length) {
       const firstError = error.errors[0];
+      const propName = firstError.path.length ? firstError.path.join('.') : 'param';
       return {
-        error: httpErrors.badRequest(`Invalid ${firstError.path.join('.')}: ${error.errors[0].message}`),
+        error: httpErrors.badRequest(`Invalid ${propName}: ${error.errors[0].message}`),
       };
     }
     return { error };

--- a/src/routes/bitcoin/block.ts
+++ b/src/routes/bitcoin/block.ts
@@ -13,7 +13,7 @@ const blockRoutes: FastifyPluginCallback<Record<never, never>, Server, ZodTypePr
         description: 'Get a block by its hash',
         tags: ['Bitcoin'],
         params: z.object({
-          hash: z.string().describe('The Bitcoin block hash'),
+          hash: z.string().length(64, 'should be a 64-character hex string').describe('The Bitcoin block hash'),
         }),
         response: {
           200: Block,
@@ -35,7 +35,7 @@ const blockRoutes: FastifyPluginCallback<Record<never, never>, Server, ZodTypePr
         description: 'Get block transaction ids by its hash',
         tags: ['Bitcoin'],
         params: z.object({
-          hash: z.string().describe('The Bitcoin block hash'),
+          hash: z.string().length(64, 'should be a 64-character hex string').describe('The Bitcoin block hash'),
         }),
         response: {
           200: z.object({
@@ -59,7 +59,7 @@ const blockRoutes: FastifyPluginCallback<Record<never, never>, Server, ZodTypePr
         description: 'Get a block header by its hash',
         tags: ['Bitcoin'],
         params: z.object({
-          hash: z.string().describe('The Bitcoin block hash'),
+          hash: z.string().length(64, 'should be a 64-character hex string').describe('The Bitcoin block hash'),
         }),
         response: {
           200: z.object({
@@ -85,7 +85,11 @@ const blockRoutes: FastifyPluginCallback<Record<never, never>, Server, ZodTypePr
         description: 'Get a block hash by its height',
         tags: ['Bitcoin'],
         params: z.object({
-          height: z.coerce.number().describe('The Bitcoin block height'),
+          height: z
+            .string()
+            .min(1, 'cannot be empty')
+            .pipe(z.coerce.number().min(0, 'cannot be negative'))
+            .describe('The Bitcoin block height'),
         }),
         response: {
           200: z.object({

--- a/src/routes/bitcoin/transaction.ts
+++ b/src/routes/bitcoin/transaction.ts
@@ -38,7 +38,7 @@ const transactionRoutes: FastifyPluginCallback<Record<never, never>, Server, Zod
         description: 'Get a transaction by its txid',
         tags: ['Bitcoin'],
         params: z.object({
-          txid: z.string().describe('The Bitcoin transaction id'),
+          txid: z.string().length(64, 'should be a 64-character hex string').describe('The Bitcoin transaction id'),
         }),
         response: {
           200: Transaction,
@@ -62,7 +62,7 @@ const transactionRoutes: FastifyPluginCallback<Record<never, never>, Server, Zod
         description: 'Get a transaction hex by its txid',
         tags: ['Bitcoin'],
         params: z.object({
-          txid: z.string().describe('The Bitcoin transaction id'),
+          txid: z.string().length(64, 'should be a 64-character hex string').describe('The Bitcoin transaction id'),
         }),
         response: {
           200: z.object({

--- a/src/routes/rgbpp/assets.ts
+++ b/src/routes/rgbpp/assets.ts
@@ -19,7 +19,7 @@ const assetsRoute: FastifyPluginCallback<Record<never, never>, Server, ZodTypePr
         description: `Get RGB++ assets by BTC txid.`,
         tags: ['RGB++'],
         params: z.object({
-          btc_txid: z.string(),
+          btc_txid: z.string().length(64, 'Should be a 64-character hex string'),
         }),
         response: {
           200: z.array(
@@ -65,8 +65,8 @@ const assetsRoute: FastifyPluginCallback<Record<never, never>, Server, ZodTypePr
         description: 'Get RGB++ assets by btc txid and vout',
         tags: ['RGB++'],
         params: z.object({
-          btc_txid: z.string(),
-          vout: z.coerce.number(),
+          btc_txid: z.string().length(64, 'should be a 64-character hex string'),
+          vout: z.string().min(1, 'cannot be empty').pipe(z.coerce.number().min(0, 'cannot be negative')),
         }),
         response: {
           200: z.array(

--- a/src/routes/rgbpp/transaction.ts
+++ b/src/routes/rgbpp/transaction.ts
@@ -54,7 +54,7 @@ const transactionRoute: FastifyPluginCallback<Record<never, never>, Server, ZodT
         description: `Get the CKB transaction hash by BTC txid.`,
         tags: ['RGB++'],
         params: z.object({
-          btc_txid: z.string(),
+          btc_txid: z.string().length(64, 'should be a 64-character hex string'),
         }),
         response: {
           200: z.object({
@@ -116,7 +116,7 @@ const transactionRoute: FastifyPluginCallback<Record<never, never>, Server, ZodT
         `,
         tags: ['RGB++'],
         params: z.object({
-          btc_txid: z.string(),
+          btc_txid: z.string().length(64, 'should be a 64-character hex string'),
         }),
         querystring: z.object({
           with_data: z.enum(['true', 'false']).default('false'),

--- a/src/routes/rgbpp/transaction.ts
+++ b/src/routes/rgbpp/transaction.ts
@@ -22,7 +22,9 @@ const transactionRoute: FastifyPluginCallback<Record<never, never>, Server, ZodT
             }
             const parsed = CKBVirtualResult.safeParse(value);
             if (!parsed.success) {
-              throw new Error(`Invalid CKB virtual result: ${JSON.stringify(parsed.error.flatten())}`);
+              throw fastify.httpErrors.badRequest(
+                `Invalid CKB virtual result: ${JSON.stringify(parsed.error.flatten())}`,
+              );
             }
             return parsed.data;
           }),

--- a/test/routes/__snapshots__/token.test.ts.snap
+++ b/test/routes/__snapshots__/token.test.ts.snap
@@ -1,13 +1,3 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`\`/token/generate\` - without params 1`] = `
-"[
-  {
-    "code": "invalid_type",
-    "expected": "object",
-    "received": "null",
-    "path": [],
-    "message": "Expected object, received null"
-  }
-]"
-`;
+exports[`\`/token/generate\` - without params 1`] = `"Invalid param: Expected object, received null"`;


### PR DESCRIPTION
## Changes
- Add basic validation to route params (e.g. txid, hash should be 64-character hex string)
- Write a custom `validatorCompiler` to promp only the first error if  `error instanceof ZodError`

## Related issues
- Fixes #210 

## Examples

#### Route: `/rgbpp/v1/assets//`
```json
{
  "message": "Invalid btc_txid: should be a 64-character hex string"
}
```

#### Route `/rgbpp/v1/assets/63e7de3c59b7f28cfc1eb840c8d617b2f557770d2576355cfc0263e1925ac116/`
```json
{
  "message": "Invalid vout: cannot be empty"
}
```

#### Route: `/rgbpp/v1/assets/63e7de3c59b7f28cfc1eb840c8d617b2f557770d2576355cfc0263e1925ac116/-1`
```json
{
  "message": "Invalid vout: cannot be negative"
}
```
