### PR TITLE
fix: incorrect count of delayed jobs in the enqueueTransaction test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,15 +32,15 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PNPM
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "21"
           cache: "pnpm"

--- a/test/services/transaction.test.ts
+++ b/test/services/transaction.test.ts
@@ -124,11 +124,14 @@ describe('transactionProcessor', () => {
       },
     };
 
-    transactionProcessor.enqueueTransaction(transactionRequest);
-    const count = await transactionProcessor['queue'].getJobCounts();
-    const job = await transactionProcessor['queue'].getJob(transactionRequest.txid);
-    expect(count.delayed).toBe(1);
-    expect(job?.delay).toBe(cradle.env.TRANSACTION_QUEUE_JOB_DELAY);
+    await transactionProcessor.enqueueTransaction(transactionRequest);
+    const jobs = await transactionProcessor['queue'].getJobs('delayed');
+    const jobFromApi = await transactionProcessor['queue'].getJob(transactionRequest.txid);
+    const jobFromList = jobs.find((row) => row.id === transactionRequest.txid);
+
+    expect(jobFromApi).toBeDefined();
+    expect(jobFromApi!.id).toStrictEqual(jobFromList?.id);
+    expect(jobFromApi!.delay).toBe(cradle.env.TRANSACTION_QUEUE_JOB_DELAY);
   });
 
   test('retryMissingTransactions: should be retry transaction job when missing', async () => {


### PR DESCRIPTION
## Changes
- Fix #208
- Upgrade dependencies in the `test` ci

## Fix

We initially thought that #208 was a redis-related issue, but the actual problem was that other tests had pushed delayed jobs to the queue right before this one. This means that `jobs.delayed` is not always guaranteed to be `1`, depending on the execution order of the tests (they normally run in parallel, so the order is not always the same).

For example, check this action and search `jobs-xxx` for the log print of the `jobs` list, you should find 2 items in it, where one is our targeting item, and the other item belongs to another tests: https://github.com/ckb-cell/btc-assets-api/actions/runs/10662966768/job/29551165802#step:7:146